### PR TITLE
Add tick sounds during Whisper transcription

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ image = "0.25.6"
 lazy_static = "1.5.0"
 rdev = "0.5.3"
 
+rodio = "0.17"
+default-device-sink = "0.1"
+
 async-openai = "0.28.0" # Check for latest version
 tokio = { version = "1", features = [
     "full",


### PR DESCRIPTION
## Summary
- add rodio and default-device-sink for playback
- add helpers to play ticking sound while Whisper transcribes
- play failure sound if transcription fails
- wrap Whisper API call with ticking feedback

## Testing
- `cargo test` *(fails: could not compile `ocrp` for current environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859c8a8dba08332aae985d90e95a14a